### PR TITLE
Fix setting of message_format

### DIFF
--- a/src/HipChatDriver.php
+++ b/src/HipChatDriver.php
@@ -77,7 +77,7 @@ class HipChatDriver extends HttpDriver
      */
     public function buildServicePayload($message, $matchingMessage, $additionalParameters = [])
     {
-        $parameters = array_merge_recursive([
+        $parameters = array_replace_recursive([
             'message_format' => 'text',
         ], $additionalParameters);
         /*

--- a/tests/HipChatDriverTest.php
+++ b/tests/HipChatDriverTest.php
@@ -255,7 +255,7 @@ class HipChatDriverTest extends PHPUnit_Framework_TestCase
 
         // Now if the user wants to set the format to HTML
         $payload = $driver->buildServicePayload('Test message', $message, [
-            'message_format' => 'html'
+            'message_format' => 'html',
         ]);
 
         $this->assertEquals('html', $payload['message_format']);

--- a/tests/HipChatDriverTest.php
+++ b/tests/HipChatDriverTest.php
@@ -229,4 +229,35 @@ class HipChatDriverTest extends PHPUnit_Framework_TestCase
 
         $this->assertFalse($driver->isConfigured());
     }
+
+    /** @test */
+    public function it_builds_the_correct_payload()
+    {
+        // Given a user wants to send html
+        $driver = $this->getDriver([
+            'event' => 'room_message',
+            'item' => [
+                'message' => [
+                    'from' => [
+                        'id' => '12345',
+                    ],
+                    'message' => 'Hi Julia',
+                ],
+                'room' => [
+                    'id' => '98765',
+                ],
+            ],
+            'webhook_id' => '11223344',
+        ]);
+        $message = $driver->getMessages()[0];
+        $payload = $driver->buildServicePayload('Test message', $message);
+        $this->assertEquals('text', $payload['message_format']);
+
+        // Now if the user wants to set the format to HTML
+        $payload = $driver->buildServicePayload('Test message', $message, [
+            'message_format' => 'html'
+        ]);
+
+        $this->assertEquals('html', $payload['message_format']);
+    }
 }


### PR DESCRIPTION
Hello~

While working with the driver I noticed my messages weren't going out when setting message_format to html. I did some debugging and noticed that the message_format was returning an array instead of a single value.

This happened because of the use of `array_merge_recursive` which I swapped out for `array_replace_recursive` which does the trick.

Now seeing how the default parameters array only has a single key value pair this change should not impact the usage in any other way.

I've added a test to validate the value of the message_format.